### PR TITLE
Async code and in-memory storage

### DIFF
--- a/tools/DecTalk_Server/DecTalk_Server/DecTalk_Server/Program.cs
+++ b/tools/DecTalk_Server/DecTalk_Server/DecTalk_Server/Program.cs
@@ -6,84 +6,153 @@ using System.Text;
 using NAudio.Wave;
 using NAudio.Lame;
 using System.Configuration;
+using System.Threading.Tasks;
+using System.Linq;
+using System.Collections.Generic;
 
 namespace DecTalk
 {
     class Program
     {
+        static string entirePath = null;
+
+        private static Dictionary<Guid, Stream> storedStreams = new Dictionary<Guid, Stream>();
+
+        public static Stream GetStream(Guid guid)
+        {
+            lock (storedStreams)
+            {
+                return storedStreams[guid];
+            }
+        }
+
+        public static void AddStream(Guid guid, Stream stream)
+        {
+            lock (storedStreams)
+            {
+                storedStreams.Add(guid, stream);
+            }
+        }
+
+        public static void RemoveStream(Guid guid)
+        {
+            lock (storedStreams)
+            {
+                storedStreams.Remove(guid);
+            }
+        }
+
         static void Main(string[] args)
         {
             HttpListener listener = null;
-            var path = "./temp.mp3";
             var server = ConfigurationManager.AppSettings["server"];
             var port = ConfigurationManager.AppSettings["port"];
-            string entirePath = null;
+
 
             if (port == "0") entirePath = "http://" + server + "/";
             else entirePath = "http://" + server + ":" + port + "/";
 
-            try {
-                listener = new HttpListener();
-                listener.Prefixes.Add(entirePath);
-                listener.Start();
-                while (true)
+
+            listener = new HttpListener();
+            listener.Prefixes.Add(entirePath);
+            listener.Start();
+            Task.Run(async () =>
+            {
+                try
                 {
-                    Console.WriteLine("Awaiting Connection...");
-                    HttpListenerContext context = listener.GetContext();
-                    if(!String.IsNullOrEmpty(context.Request.QueryString["tts"]))
+                    while (true)
                     {
-                       string msg = Convert.ToString(context.Request.QueryString["tts"]);
-                        Console.WriteLine(msg);
-                        using (var tts = new FonixTalkEngine(LanguageCode.EnglishUS))
-                        {
-                            tts.SpeakToWavFile("temp.wav", msg);
-                        }
-
-                        WaveToMP3("temp.wav", "temp.mp3");
-
-
-                        string filePath = entirePath + "temp.mp3";
-                        byte[] getBytes = Encoding.ASCII.GetBytes(filePath);
-                        System.IO.Stream output = context.Response.OutputStream;
-                        context.Response.ContentType = "text/plain";
-                        output.Write(getBytes, 0, getBytes.Length);
-                        output.Close();
-
-
-
-                    }
-                    if(context.Request.Url.AbsolutePath.EndsWith(".mp3"))
-                    {
-                        try
-                        {
-                            using (FileStream fs = File.Open(path, FileMode.Open, FileAccess.Read))
-                            {
-                                Console.WriteLine("Sent file to client");
-                                System.IO.Stream output = context.Response.OutputStream;
-                                context.Response.ContentType = "audio/mpeg";
-                                fs.CopyTo(output);
-                                output.Close();
-                            }
-                        } catch (FileNotFoundException e)
-                        {
-                            Console.WriteLine("File was not found with: " + context.Request.Url.LocalPath);
-
-                        }
+                        Console.WriteLine("Awaiting Connection...");
+                        HttpListenerContext context = await listener.GetContextAsync();
+                        Task.Run(async () => await ProcessRequest(context));
                     }
                 }
-            } catch (HttpListenerException e) {
-                Console.WriteLine("Error Code: " + e.ErrorCode);
-                Console.WriteLine(e.Message);
-                Console.ReadLine();
-                
+                catch (HttpListenerException e)
+                {
+                    Console.WriteLine("Error Code: " + e.ErrorCode);
+                    Console.WriteLine(e.Message);
+                    Console.ReadLine();
+
+                }
+            });
+        }
+
+        public static async Task<Stream> WaveToMP3(Stream wavStream, int bitRate = 128)
+        {
+            Stream outStream = new MemoryStream();
+            using (var reader = new RawSourceWaveStream(wavStream, new WaveFormat()))
+            {
+                using (var writer = new LameMP3FileWriter(outStream, new Mp3WaveFormat(11025, 1, 16, bitRate), bitRate))
+                {
+                    await reader.CopyToAsync(writer);
+                    return outStream;
+                }
             }
         }
 
-        public static void WaveToMP3(string waveFileName, string mp3FileName, int bitRate = 128)
+        public static async Task ProcessRequest(HttpListenerContext context)
         {
-            using (var reader = new WaveFileReader(waveFileName))
-            using (var writer = new LameMP3FileWriter(mp3FileName, reader.WaveFormat, bitRate))
-                reader.CopyTo(writer);
+            if (!String.IsNullOrEmpty(context.Request.QueryString["tts"]))
+            {
+                string msg = Convert.ToString(context.Request.QueryString["tts"]);
+                Console.WriteLine(msg);
+
+                Stream voiceStream = new MemoryStream();
+
+                using (var tts = new FonixTalkEngine(LanguageCode.EnglishUS))
+                {
+                    tts.SpeakToStream(voiceStream, msg);
+                }
+
+                //We've written, so we have to go back to the top
+                voiceStream.Seek(0, SeekOrigin.Begin);
+
+                //Converts to MP3
+                voiceStream = await WaveToMP3(voiceStream);
+
+                //Resets to the top again
+                voiceStream.Seek(0, SeekOrigin.Begin);
+
+                //Generates a new file guid to keep the file in
+                Guid fileGuid = Guid.NewGuid();
+
+                AddStream(fileGuid, voiceStream);
+
+                string streampath = entirePath + fileGuid.ToString();
+
+                byte[] getBytes = Encoding.ASCII.GetBytes(streampath);
+                System.IO.Stream output = context.Response.OutputStream;
+                context.Response.ContentType = "text/plain";
+                await output.WriteAsync(getBytes, 0, getBytes.Length);
+                output.Close();
+            }
+
+            else
+            {
+                try
+                {
+                    //Gets the guid requested from the end of the url
+                    Guid requested;
+                    if (Guid.TryParse(context.Request.Url.Segments.Last(), out requested))
+                    {
+                        using (Stream stream = GetStream(requested))
+                        {
+                            Console.WriteLine("Sent file to client");
+                            System.IO.Stream output = context.Response.OutputStream;
+                            context.Response.ContentType = "audio/mpeg";
+                            await stream.CopyToAsync(output);
+                            output.Close();
+                        }
+
+                        RemoveStream(requested);
+                    }
+                }
+                catch (FileNotFoundException e)
+                {
+                    Console.WriteLine("File was not found with: " + context.Request.Url.LocalPath);
+
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
<!--
Pull requests must be atomic.  Change one set of related things at a time.  Bundling sucks for everyone.
This means, primarily, that you shouldn't fix bugs and add content in the same PR. When we mean 'bundling', we mean making one PR for multiple, unrelated changes.

Test your changes.  PRs that do not compile will not be accepted.
Testing your changes locally is incredibly important. If you break the serb we will be very upset with you.

Large changes require discussion.  If you're doing a large, game-changing modification, or a new layout for something, discussion with the community is required as of 26/6/2014.  Map and sprite changes require pictures of before and after.  MAINTAINERS ARE NOT IMMUNE TO THIS.  GET YOUR ASS IN IRC.

Merging your own PRs is considered bad practice, as it generally means you bypass peer review, which is a core part of how we develop.

It is also suggested that you hop into irc.rizon.net #vgstation to discuss your changes, or if you need help.
-->


Requests are now handled in the thread pool asynchronously
Requests now generate a guid which is used for their callback
Requests now generate all data in-memory without using files